### PR TITLE
Added template for container with kubectl and helm

### DIFF
--- a/k8s-helm/Dockerfile
+++ b/k8s-helm/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
+# This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+
+FROM centos:7
+ARG HELMVERSION="v2.14.3" 
+ARG KUBECTLVERSION="v1.15.3" 
+
+RUN yum install -y wget
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTLVERSION}/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/kubectl && mkdir /root/.kube
+
+RUN wget https://storage.googleapis.com/kubernetes-helm/helm-${HELMVERSION}-linux-amd64.tar.gz && \
+    tar -zxvf helm-${HELMVERSION}-linux-amd64.tar.gz && \
+    chmod +x linux-amd64/helm && \
+    mv linux-amd64/helm /usr/local/bin/helm && \
+    rm helm-${HELMVERSION}-linux-amd64.tar.gz && \
+    rm -rf linux-amd64

--- a/k8s-helm/README.rst
+++ b/k8s-helm/README.rst
@@ -1,0 +1,8 @@
+--------------
+k8s_helm
+--------------
+
+A container image that jenkins uses to authenticate to any generic kubernetes cluster through kubectl and perform a deployment through `Helm`_
+
+KUBECTLVERSION - Version of kubectl to intstall
+HELMVERSION    - Version of Helm to install


### PR DESCRIPTION
# PR Details

Template for k8s-helm image with kubectl and helm binaries installed

## Description

Added template to build container 'k8s-helm' used by sdp kubernetes library to deploy workloads into a generic kubernetes cluster

## How Has This Been Tested

This image has been tested with the sdp kubernetes library to deploy k8s workloads

## Types of Changes

<!--What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.