### PR TITLE
Default UBI based sdp container image containing commonly used utilities 

### DIFF
--- a/default-sdp/Dockerfile
+++ b/default-sdp/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
+# This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+
+FROM registry.access.redhat.com/ubi8/ubi:8.2
+
+LABEL name="Solutions Delivery Platform: Default Basic SDP Image" \
+      maintainer="terrana_steven@bah.com" \
+      vendor="Booz Allen Hamilton" \
+      summary="Default SDP container" \
+      description="This container is the default container for SDP pipeline library containing some common utilities"
+
+RUN INSTALL_PKGS="git wget make " && \
+    yum -y update  && \
+    yum -y install --setopt=tsflags=nodocs ${INSTALL_PKGS}
+
+ARG user=sdpuser
+ARG group=sdpuser
+ARG uid=1000
+ARG gid=1000
+ARG SDP_HOME=/var/sdp
+
+RUN mkdir -p $SDP_HOME \
+  && chown ${uid}:${gid} $SDP_HOME \
+  && groupadd -g ${gid} ${group} \
+  && useradd -d "$SDP_HOME" -u ${uid} -g ${gid} -m -s /bin/bash ${user}
+
+USER ${user}
+WORKDIR $SDP_HOME
+CMD ["/bin/bash"]

--- a/default-sdp/Makefile
+++ b/default-sdp/Makefile
@@ -1,0 +1,37 @@
+OWNER    = boozallen
+REPO     = sdp-images
+IMAGE    = default-sdp
+VERSION  = 1.0
+
+REGISTRY = docker.pkg.github.com/$(OWNER)/$(REPO)
+TAG      = $(REGISTRY)/$(IMAGE):$(VERSION)
+
+.PHONY: help Makefile 
+.ONESHELL: push 
+
+
+# Put it first so that "make" without argument is like "make help".
+help: ## Show target options
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+build: ## build container image 
+	docker build . -t $(TAG)
+
+push: ## builds and publishes container image 
+	$(eval user := $(shell read -p "GitHub Username: " username; echo $$username))
+	$(eval pass := $(shell read -s -r -p "GitHub Token: " token; echo $$token))
+	@echo 
+	@docker login $(REGISTRY) -u $(user) -p $(pass); 
+	make build 
+	docker tag $(TAG) $(REGISTRY)/$(IMAGE):latest
+	docker push $(TAG)
+	docker push $(REGISTRY)/$(IMAGE):latest
+
+info: 
+	@echo "$(TAG) -> $$(dirname $$(git ls-files --full-name Makefile))"
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	echo "Make command $@ not found" 
+

--- a/default-sdp/README.rst
+++ b/default-sdp/README.rst
@@ -1,0 +1,5 @@
+-------------
+default-sdp
+-------------
+
+A container image that contains common packages and is the default container image used by sdp library 

--- a/default-sdp/README.rst
+++ b/default-sdp/README.rst
@@ -2,4 +2,4 @@
 default-sdp
 -------------
 
-A container image that contains common packages and is the default container image used by sdp library 
+An UBI based  container image that contains commonly used utilities and is the default container image used by sdp library 


### PR DESCRIPTION
# PR Details

This folder contains instructions to build and push an UBI based container image with commonly used utilities. This container image is intended to be used as the default basic sdp image for pipeline steps.

## Description

Added 
- Dockerfile
- Makefile
- README

## How Has This Been Tested
Tested with make build 
**TBD**
Please use make push to publish package after PR has been approved
Please run make docs once PR has been approved (otherwise generates too many files in the commit that are not relevant for this PR review) 

## Types of Changes
- [ x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (Please run make docs after PR approval)