### PR TITLE
Webhint Version Change / Dockerfile fix

### DIFF
--- a/webhint/.hintrc
+++ b/webhint/.hintrc
@@ -1,6 +1,0 @@
-{
-    "extends": [
-        "accessibility"
-    ],
-    "formatters": ["json"]
-}

--- a/webhint/Dockerfile
+++ b/webhint/Dockerfile
@@ -1,29 +1,36 @@
+# Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
+# This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+
 FROM alpine:edge
+
 # Installs latest Chromium (77) package.
 RUN apk add --no-cache \
-   chromium \
-   nss \
-   freetype \
-   freetype-dev \
-   harfbuzz \
-   ca-certificates \
-   ttf-freefont \
-   nodejs \
-   npm
+    chromium \
+    nss \
+    freetype \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont \
+    nodejs \
+    npm
    
-# Tell Puppeteer to skip installing Chrome. We’ll be using the installed package.
+# Tell Puppeteer to skip installing Chrome
+# Set execution path
+# Browser cli configuration for root usage
+# Hint feedback off to avoid erroring out no input from confirmation question
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
-  PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
-  CHROMIUM_FLAGS="--no-sandbox --headless" \
-  HINT_TELEMETRY=off
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
+    CHROMIUM_FLAGS="--no-sandbox --headless" \
+    HINT_TELEMETRY=off
 
 RUN npm i -g puppeteer@5.2.1 hint --silent --no-warnings
 
+# Sanity checking - also crashes build if something didn't install correctly which we want
 RUN set -x \
-  && node -v \
-  && npm -v \
-  && npx -v \
-  && hint -v
+    && node -v \
+    && npm -v \
+    && npx -v \
+    && hint -v
 
-WORKDIR hint
-COPY .hintrc .
+COPY .hintrc /hint/

--- a/webhint/Dockerfile
+++ b/webhint/Dockerfile
@@ -32,5 +32,3 @@ RUN set -x \
     && npm -v \
     && npx -v \
     && hint -v
-
-COPY .hintrc /hint/

--- a/webhint/Makefile
+++ b/webhint/Makefile
@@ -1,4 +1,4 @@
-OWNER    = johnson-jesse
+OWNER    = boozallen
 REPO     = sdp-images
 IMAGE    = webhint
 VERSION  = 1.9

--- a/webhint/Makefile
+++ b/webhint/Makefile
@@ -1,7 +1,7 @@
 OWNER    = boozallen
 REPO     = sdp-images
 IMAGE    = webhint
-VERSION  = 1.0
+VERSION  = 1.1
 
 REGISTRY = docker.pkg.github.com/$(OWNER)/$(REPO)
 TAG      = $(REGISTRY)/$(IMAGE):$(VERSION)

--- a/webhint/Makefile
+++ b/webhint/Makefile
@@ -1,4 +1,4 @@
-OWNER    = boozallen
+OWNER    = johnson-jesse
 REPO     = sdp-images
 IMAGE    = webhint
 VERSION  = 1.1

--- a/webhint/Makefile
+++ b/webhint/Makefile
@@ -1,7 +1,7 @@
 OWNER    = johnson-jesse
 REPO     = sdp-images
 IMAGE    = webhint
-VERSION  = 1.1
+VERSION  = 1.9
 
 REGISTRY = docker.pkg.github.com/$(OWNER)/$(REPO)
 TAG      = $(REGISTRY)/$(IMAGE):$(VERSION)


### PR DESCRIPTION
# PR Details

- Updated image version in Makefile
- Added license comment to Dockerfile
- Added formatting to Dockerfile
- Removed `WORKDIR` command in Dockerfile
- Updated `COPY` command in Dockerfile

## Description

Without a version change, the process to update `:latest` fails. This now should give me a new image entry and allow me to leave the image definition as `"webhint"` and see the latest .hintrc file.

## How Has This Been Tested

- Unable to test this flow outside this DevOps pipeline
- New images failed to get tagged and thus changes to .hintrc file not seen

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.