### PR TITLE
adding nvm image

### DIFF
--- a/nvm/Dockerfile
+++ b/nvm/Dockerfile
@@ -1,0 +1,16 @@
+# Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
+# This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+
+ARG BASE_REGISTRY=registry.access.redhat.com
+ARG BASE_IMAGE=ubi8/ubi
+ARG BASE_TAG=8.3
+FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
+
+SHELL ["/bin/bash", "-c"]
+ARG NVM_VERSION=v0.38.0
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash
+
+RUN source ~/.bashrc && nvm install 'lts/*'
+
+CMD ["/bin/bash"]

--- a/nvm/Makefile
+++ b/nvm/Makefile
@@ -1,0 +1,37 @@
+OWNER    = boozallen
+REPO     = sdp-images
+IMAGE    = nvm
+VERSION  = 1.0.0
+
+REGISTRY = docker.pkg.github.com/$(OWNER)/$(REPO)
+TAG      = $(REGISTRY)/$(IMAGE):$(VERSION)
+
+.PHONY: help Makefile 
+.ONESHELL: push 
+
+
+# Put it first so that "make" without argument is like "make help".
+help: ## Show target options
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+build: ## build container image 
+	docker build . -t $(TAG)
+
+push: ## builds and publishes container image 
+	$(eval user := $(shell read -p "GitHub Username: " username; echo $$username))
+	$(eval pass := $(shell read -s -r -p "GitHub Token: " token; echo $$token))
+	@echo 
+	@docker login $(REGISTRY) -u $(user) -p $(pass); 
+	make build 
+	docker tag $(TAG) $(REGISTRY)/$(IMAGE):latest
+	docker push $(TAG)
+	docker push $(REGISTRY)/$(IMAGE):latest
+
+info: 
+	@echo "$(TAG) -> $$(dirname $$(git ls-files --full-name Makefile))"
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	echo "Make command $@ not found" 
+

--- a/nvm/README.rst
+++ b/nvm/README.rst
@@ -1,0 +1,7 @@
+-------------
+nvm
+-------------
+
+A ubi8/ubi image with nvm installed. Can be used to easily specify a version of nodeJs to run.
+
+

--- a/nvm/README.rst
+++ b/nvm/README.rst
@@ -1,7 +1,14 @@
 -------------
-nvm
+Node Version Manager
 -------------
 
-A ubi8/ubi image with nvm installed. Can be used to easily specify a version of nodeJs to run.
+A ubi8/ubi image with node version manager (nvm) installed. Can be used to easily specify a version of nodeJs to run.
 
 
+To use, source nvm and follow `nvm usage <https://github.com/nvm-sh/nvm#usage>` instructions:
+
+To install the lts version of nodejs, for example, run:
+```
+source ~/.bashrc
+nvm install '*/lts'
+```


### PR DESCRIPTION
# PR Details

Adds a Node Version Manager sdp-image, for running specified versions of nodejs.

## Description

This image is required for the npm library update to sdp-library. It installs nvm on a ubi8/ubi base image.

## How Has This Been Tested

Built this image locally, and tested on a local jenkins, using the npm sdp-library.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.