### PR TITLE
adding a basic Maven 3.8 / OpenJDK 11 image

### DIFF
--- a/mvn/Dockerfile
+++ b/mvn/Dockerfile
@@ -1,0 +1,46 @@
+# Copyright © 2022 Booz Allen Hamilton. All Rights Reserved.
+# This software package is licensed under the Booz Allen Public License. 
+# The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+
+ARG BASE_REGISTRY=registry.access.redhat.com
+ARG BASE_IMAGE=ubi8/ubi
+ARG BASE_TAG=8.6-754
+
+# importing Maven from public image (version available from UBI base package repos is for JDK8)
+FROM maven:3.8.5-openjdk-11 as base
+
+FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
+
+RUN dnf update -y && \
+    dnf install -y java-11-openjdk java-11-openjdk-devel && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+ARG USER=maven \
+    GROUP=maven \
+    UID=1001 \
+    GID=1001
+
+ENV LANG=C.UTF-8 \
+    HOME=/home/maven \
+    MAVEN_HOME=/usr/share/maven \
+    MAVEN_CONFIG=/home/maven/.m2 \
+    MAVEN_VERSION=3.8 \
+    JAVA_HOME=/usr/lib/jvm/java \
+    JAVA_VENDOR=openjdk \
+    JAVA_VERSION=11
+ENV PATH=$JAVA_HOME/bin:$PATH
+
+RUN mkdir -p ${MAVEN_CONFIG} && \
+    groupadd -r -g ${GID} ${GROUP} && \
+    useradd -r -s /sbin/nologin -u ${UID} -g ${GID} ${USER} && \
+    chown -R ${UID}:${GID} ${HOME} && \
+    chmod g=u ${HOME} && \
+    ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+COPY --from=base ${MAVEN_HOME} ${MAVEN_HOME}
+
+WORKDIR ${HOME}
+USER ${USER}
+
+CMD ["mvn"]

--- a/mvn/Makefile
+++ b/mvn/Makefile
@@ -1,0 +1,37 @@
+OWNER    = boozallen
+REPO     = sdp-images
+IMAGE    = mvn
+VERSION  = 3.8.5
+
+REGISTRY = docker.pkg.github.com/$(OWNER)/$(REPO)
+TAG      = $(REGISTRY)/$(IMAGE):$(VERSION)
+
+.PHONY: help Makefile 
+.ONESHELL: push 
+
+
+# Put it first so that "make" without argument is like "make help".
+help: ## Show target options
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+build: ## build container image 
+	docker build --no-cache . -t $(TAG)
+
+push: ## builds and publishes container image 
+	$(eval user := $(shell read -p "GitHub Username: " username; echo $$username))
+	$(eval pass := $(shell read -s -r -p "GitHub Token: " token; echo $$token))
+	@echo 
+	@docker login $(REGISTRY) -u $(user) -p $(pass); 
+	make build 
+	docker tag $(TAG) $(REGISTRY)/$(IMAGE):latest
+	docker push $(TAG)
+	docker push $(REGISTRY)/$(IMAGE):latest
+
+info: 
+	@echo "$(TAG) -> $$(dirname $$(git ls-files --full-name Makefile))"
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	echo "Make command $@ not found" 
+

--- a/mvn/README.rst
+++ b/mvn/README.rst
@@ -1,0 +1,5 @@
+-------------
+Maven
+-------------
+
+A ubi8 image with OpenJDK 11 and Maven (mvn) 3.8.5 installed. Can be used to run any Maven phases/goals.


### PR DESCRIPTION
# PR Details

Would like to add a Maven container image to SDP Images to support development of a new `maven` SDP Library.

## Description

Uses the Red Hat UBI 8.6 base image
OpenJDK-11 installed from the default package repositories
Maven is copied into the container from the public Docker Hub `maven:3.8.5-openjdk-11` image

## How Has This Been Tested

Locally, with `make build`

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.