### PR TITLE
Upgrade Maven and JDK version in the mvn image

### DIFF
--- a/mvn/Dockerfile
+++ b/mvn/Dockerfile
@@ -7,12 +7,12 @@ ARG BASE_IMAGE=ubi8/ubi
 ARG BASE_TAG=8.6-754
 
 # importing Maven from public image (version available from UBI base package repos is for JDK8)
-FROM maven:3.8.5-openjdk-11 as base
+FROM maven:3.8.6-openjdk-18 as base
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 RUN dnf update -y && \
-    dnf install -y java-11-openjdk java-11-openjdk-devel && \
+    dnf install -y java-17-openjdk java-17-openjdk-devel && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
@@ -25,10 +25,10 @@ ENV LANG=C.UTF-8 \
     HOME=/home/maven \
     MAVEN_HOME=/usr/share/maven \
     MAVEN_CONFIG=/home/maven/.m2 \
-    MAVEN_VERSION=3.8 \
+    MAVEN_VERSION=3.8.6 \
     JAVA_HOME=/usr/lib/jvm/java \
     JAVA_VENDOR=openjdk \
-    JAVA_VERSION=11
+    JAVA_VERSION=17
 ENV PATH=$JAVA_HOME/bin:$PATH
 
 RUN mkdir -p ${MAVEN_CONFIG} && \


### PR DESCRIPTION
# PR Details

Upgrades **Maven** to version **3.8.6** and the JDK to **openjdk-17**.

## Description

Levages the existing installation methods to install the upgraded versions mentioned above for the **mvn** container image.

## How Has This Been Tested

This was tested locally with the Java scaffold on my Mac laptop using the following steps:

1. Build the **mvn** image with the command: `docker build -t mvn .`
2. Substitute the **mvn** image in the build stage of the _Dockerfile.local_ of the Java scaffold
3. Run the CookieCutter script
4. Run the build with the following command: `docker-compose build`
5. Start the application with `docker-compose up`

The application builds and runs successfully in the container.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.