### PR TITLE
Bug Fix: Error from .Net Assembly Analyzer

### DIFF
--- a/owasp-dep-check/Dockerfile
+++ b/owasp-dep-check/Dockerfile
@@ -8,7 +8,7 @@ COPY LICENSE /licenses
 
 ### Update and install required packages
 RUN dnf update -y --nodocs && \
-    dnf install -y java-17-openjdk-devel unzip && \
+    dnf install -y java-17-openjdk-devel unzip dotnet-sdk-6.0.x86_64 && \
     dnf module install -y nodejs:16 && \
     dnf clean all && \
     npm install --global yarn && \
@@ -43,7 +43,7 @@ RUN chmod +x /usr/share/dependency-check/bin/container-entrypoint.sh
 USER ${UID}
 
 ### Pull latest NVD data
-RUN /usr/share/dependency-check/bin/dependency-check.sh --updateonly
+RUN /usr/share/dependency-check/bin/dependency-check.sh --enableExperimental --updateonly
 
 VOLUME ["/src", "/report"]
 WORKDIR /src

--- a/owasp-dep-check/Makefile
+++ b/owasp-dep-check/Makefile
@@ -1,7 +1,7 @@
 OWNER    = boozallen
 REPO     = sdp-images
 IMAGE    = owasp-dep-check
-VERSION  = 7.3.0
+VERSION  = 7.3.0-8.6
 
 REGISTRY = docker.pkg.github.com/$(OWNER)/$(REPO)
 TAG      = $(REGISTRY)/$(IMAGE):$(VERSION)


### PR DESCRIPTION
# PR Details

Bug fixing an error encountered when running the .Net Assembly Analyzer.

## Description

.Net Core 6.x needs to be included in the image to ensure complied/assembled .Net projects can be properly analyzed.
Added the `--enableExperimental` flag to the initial db pull to mirror SDP library functionality and ensure we pull info for all analyzers.
Bumped the version tag to `7.3.0-8.6`

## How Has This Been Tested

Locally, by running unit tests on a scaffolded .Net project, followed by an OWASP Dependency Check with the same set of flags used in the library/pipeline.

## Types of Changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.